### PR TITLE
Add fan to expansion_rule

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -50,7 +50,7 @@ lists:
         out: "fahrenheit"
 expansion_rules:
   lamp: "[de|het] (lamp[en]|licht[en]|verlichting)"
-  ventilator: "[de] (ventilator[s|en])"
+  ventilator: "[de] (ventilator[s|en]|fan[s])"
   afdekking: "[de|het] (gordijn[en]|vitrage[s]|jaloezie[ën]|rolluik[en]|screen[s]|luxaflex|scherm[en])"
   name: "[de|het] {name}"
   area: "[de|het] {area}"


### PR DESCRIPTION
Even though fan is not a Dutch word, it's pretty common to say fan in a Dutch sentence. Can we add fan to the expansion rule?